### PR TITLE
exclude hidden file

### DIFF
--- a/local.go
+++ b/local.go
@@ -41,6 +41,11 @@ func LocalAssets(path string) ([]string, error) {
 			continue
 		}
 
+		// Exclude hidden file
+		if filepath.Base(f)[0] == '.' {
+			continue
+		}
+
 		assets = append(assets, f)
 	}
 


### PR DESCRIPTION
I think it should exclude hidden files, e.g. `.gitignore` `.gitkeep`.
How do you think?